### PR TITLE
use TimeTask to only run once

### DIFF
--- a/haxe/ui/backend/CallLaterBase.hx
+++ b/haxe/ui/backend/CallLaterBase.hx
@@ -4,6 +4,6 @@ import kha.Scheduler;
 
 class CallLaterBase {
     public function new(fn:Void->Void) {
-        Scheduler.addFrameTask(fn, 0);
+        Scheduler.addTimeTask(fn, 0);
     }
 }


### PR DESCRIPTION
`Scheduler.addFrameTask` adds a callback that get's called every frame. When reading the code for other backends, it seems it's only supposed to run once (an it's what i expected it would do). `Scheduler.addTimeTask` without period set (3rd parameter) will only run once.
