### PR TITLE
Timer fix

### DIFF
--- a/haxe/ui/backend/CallLaterBase.hx
+++ b/haxe/ui/backend/CallLaterBase.hx
@@ -2,8 +2,11 @@ package haxe.ui.backend;
 
 import kha.Scheduler;
 
-class CallLaterBase {
+class CallLaterBase extends TimerBase {
     public function new(fn:Void->Void) {
-        Scheduler.addFrameTask(fn, 0);
+        super(0, function() {
+            stop();
+            fn();
+        });
     }
 }

--- a/haxe/ui/backend/CallLaterBase.hx
+++ b/haxe/ui/backend/CallLaterBase.hx
@@ -2,11 +2,10 @@ package haxe.ui.backend;
 
 import kha.Scheduler;
 
-class CallLaterBase extends TimerBase {
+class CallLaterBase {
     public function new(fn:Void->Void) {
-        super(0, function() {
-            stop();
-            fn();
-        });
+        haxe.Timer.delay(function() {
+            Scheduler.addTimeTask(fn, 0);
+        }, 1); //Avoids infinite loop execution in `Kha.Scheduler.executeTimeTasks` if `callLater` is called from another callLater's callback
     }
 }

--- a/haxe/ui/backend/CallLaterBase.hx
+++ b/haxe/ui/backend/CallLaterBase.hx
@@ -4,8 +4,6 @@ import kha.Scheduler;
 
 class CallLaterBase {
     public function new(fn:Void->Void) {
-        haxe.Timer.delay(function() {
-            Scheduler.addTimeTask(fn, 0);
-        }, 1); //Avoids infinite loop execution in `Kha.Scheduler.executeTimeTasks` if `callLater` is called from another callLater's callback
+        Scheduler.addTimeTask(fn, 0.001);
     }
 }

--- a/haxe/ui/backend/TimerBase.hx
+++ b/haxe/ui/backend/TimerBase.hx
@@ -3,13 +3,25 @@ package haxe.ui.backend;
 import kha.Scheduler;
 
 class TimerBase {
-    private var _timerId:Int;
+    private var _timerId:Int = -1;
+    private var _stopped:Bool = false;  //Needed if the stop method is called in the callback execution
 
     public function new(delay:Int, callback:Void->Void) {
-        _timerId = Scheduler.addTimeTask(callback, 0, delay / 1000);
+        haxe.Timer.delay(function() {
+            _timerId = Scheduler.addBreakableTimeTaskToGroup(0, function() {
+                if (_stopped == false) {
+                    callback();
+                }
+
+                return !_stopped;
+            }, 0, delay / 1000);
+        }, 1);  //Avoids infinite loop execution in `Kha.Scheduler.executeTimeTasks`
     }
 
     public function stop() {
-        Scheduler.removeTimeTask(_timerId);
+        if (_timerId != -1) {
+            _stopped = true;
+            Scheduler.removeTimeTask(_timerId);
+        }
     }
 }

--- a/haxe/ui/backend/TimerBase.hx
+++ b/haxe/ui/backend/TimerBase.hx
@@ -7,21 +7,17 @@ class TimerBase {
     private var _stopped:Bool = false;  //Needed if the stop method is called in the callback execution
 
     public function new(delay:Int, callback:Void->Void) {
-        haxe.Timer.delay(function() {
-            _timerId = Scheduler.addBreakableTimeTaskToGroup(0, function() {
-                if (_stopped == false) {
-                    callback();
-                }
+        _timerId = Scheduler.addBreakableTimeTaskToGroup(0, function() {
+            if (_stopped == false) {
+                callback();
+            }
 
-                return !_stopped;
-            }, 0, delay / 1000);
-        }, 1);  //Avoids infinite loop execution in `Kha.Scheduler.executeTimeTasks`
+            return !_stopped;
+        }, 0, delay / 1000);
     }
 
     public function stop() {
         _stopped = true;
-        if (_timerId != -1) {
-            Scheduler.removeTimeTask(_timerId);
-        }
+        Scheduler.removeTimeTask(_timerId);
     }
 }

--- a/haxe/ui/backend/TimerBase.hx
+++ b/haxe/ui/backend/TimerBase.hx
@@ -19,8 +19,8 @@ class TimerBase {
     }
 
     public function stop() {
+        _stopped = true;
         if (_timerId != -1) {
-            _stopped = true;
             Scheduler.removeTimeTask(_timerId);
         }
     }


### PR DESCRIPTION
Related to #21 , but this PR is a better solution I think.

1. The TimerBase has problems. If you calls the stop method while the callback is in execution, the TimeTask isn't deleted and it continues executing forever (because Kha removes the activeTimer while it is executing, and add it again to the queue if the callback function in `addBreakableTimeTaskToGroup` returns `true`);

2. CallLaterBase and `addFrameTask` doesn't work like that. The second parameter is `priority`, not `delay`. And it returns a `taskid`, that it should be removed when the callback is executed. But it has the same problem that I have described in the first point.

3. If you calls `callLater` from another callLater's callback, then Kha is executing the `kha.Scheduler.executeTimeTasks` method in infinite loop, because it executes the tasks while the length > 0 ( `while(kha_Scheduler.timeTasks.length > 0)`). So, it doesn't finish never. We need a real `haxe.Timer.delay` call at least.
