### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,21 @@
-sudo: false
-language: haxe
+dist: xenial
+addons:
+  apt:
+    packages:
+    - libxinerama-dev
+    - libasound2-dev
+    - mesa-common-dev
+    - libgl-dev
+    - libxi-dev
+    - zip
+
+language: node_js
+node_js: 10
+
+env:
+  - BUILD_TARGET=debug-html5 BUILD_OPTS=""
+  - BUILD_TARGET=linux BUILD_OPTS="--compile"
+  - BUILD_TARGET=html5 BUILD_OPTS=""
 
 notifications:
   webhooks:
@@ -9,32 +25,17 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-os:
-  - linux
-
-haxe:
-  - "3.2.1"
-  - development
-
-node_js:
-  - "8"
-
 before_install:
-    - nvm install v8
-    - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
-    - haxelib dev haxeui-core haxeui-core
+  # - nvm install v8
+  - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
+  - haxelib dev haxeui-core haxeui-core
 
 install:
-    - haxelib install hscript
-    - haxelib dev haxeui-kha $TRAVIS_BUILD_DIR
-
+  - haxelib install hscript
+  - haxelib dev haxeui-kha $TRAVIS_BUILD_DIR
 
 script:
-    - git clone https://github.com/haxeui/haxeui-templates.git --depth=1
-    - cd haxeui-templates/kha/skeleton
-    - git init
-    - git submodule add https://github.com/KTXSoftware/Kha
-    - git submodule update --init --recursive
-    - node Kha/make html5
-    - cd build
-    - haxe project-html5.hxml
+  - git clone https://github.com/sh-dave/haxeui-templates.git --depth=1
+  - cd haxeui-templates/kha/skeleton
+  - git clone --recursive --single-branch https://github.com/Kode/Kha.git
+  - node Kha/make $BUILD_TARGET $BUILD_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ notifications:
 
 before_install:
   # - nvm install v8
-  - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
+  # - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
+  - git clone https://github.com/haxeui/haxeui-core.git --depth=1
   - haxelib dev haxeui-core haxeui-core
 
 install:
@@ -37,5 +38,5 @@ install:
 script:
   - git clone https://github.com/sh-dave/haxeui-templates.git --depth=1
   - cd haxeui-templates/kha/skeleton
-  - git clone --recursive --single-branch https://github.com/Kode/Kha.git
+  - git clone --recursive --single-branch --depth=1 https://github.com/Kode/Kha.git
   - node Kha/make $BUILD_TARGET $BUILD_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ node_js: 10
 
 env:
   - BUILD_TARGET=debug-html5 BUILD_OPTS=""
-  - BUILD_TARGET=linux BUILD_OPTS="--compile"
   - BUILD_TARGET=html5 BUILD_OPTS=""
+  - BUILD_TARGET=linux BUILD_OPTS="--compile"
 
 notifications:
   webhooks:
@@ -25,23 +25,14 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-# before_install:
-  # - nvm install v8
-  # - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
-  # - haxelib dev haxeui-core haxeui-core
-
-# install:
-  # - haxelib install hscript
-  # - haxelib dev haxeui-kha $TRAVIS_BUILD_DIR
-
 script:
-  - git clone --depth=1 --branch update-kha-template https://github.com/sh-dave/haxeui-templates.git
+  - git clone --depth=1 --branch update-kha-template https://github.com/haxeui/haxeui-templates.git
   - cd haxeui-templates/kha/skeleton
-  - git clone --recursive --branch fix-dce-native --single-branch --depth=1 https://github.com/sh-dave/Kha.git
+  - git clone --recursive --single-branch --depth=1 https://github.com/Kode/Kha.git
   - mkdir Libraries
   - cd Libraries
-  - git clone --single-branch --depth=1 https://github.com/haxeui/haxeui-core.git
-  - git clone --branch $TRAVIS_BRANCH --single-branch --depth=1 https://github.com/sh-dave/haxeui-kha.git
+  - git clone --branch $TRAVIS_BRANCH --single-branch --depth=1 https://github.com/haxeui/haxeui-core.git
+  - git clone --branch $TRAVIS_BRANCH --single-branch --depth=1 https://github.com/haxeui/haxeui-kha.git
   - git clone --single-branch --depth=1 https://github.com/haxefoundation/hscript.git
   - cd ..
   - node Kha/make $BUILD_TARGET $BUILD_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ notifications:
 script:
   - git clone --depth=1 --branch update-kha-template https://github.com/sh-dave/haxeui-templates.git
   - cd haxeui-templates/kha/skeleton
-  - git clone --recursive --single-branch --depth=1 https://github.com/Kode/Kha.git
+  - git clone --recursive --branch fix-dce-native --single-branch --depth=1 https://github.com/sh-dave/Kha.git
   - mkdir Libraries
   - cd Libraries
   - git clone --single-branch --depth=1 https://github.com/haxeui/haxeui-core.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,23 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-before_install:
+# before_install:
   # - nvm install v8
   # - git clone --branch $TRAVIS_BRANCH https://github.com/haxeui/haxeui-core.git --depth=1
-  - git clone https://github.com/haxeui/haxeui-core.git --depth=1
-  - haxelib dev haxeui-core haxeui-core
+  # - haxelib dev haxeui-core haxeui-core
 
-install:
-  - haxelib install hscript
-  - haxelib dev haxeui-kha $TRAVIS_BUILD_DIR
+# install:
+  # - haxelib install hscript
+  # - haxelib dev haxeui-kha $TRAVIS_BUILD_DIR
 
 script:
-  - git clone https://github.com/sh-dave/haxeui-templates.git --depth=1
+  - git clone --depth=1 --branch update-kha-template https://github.com/sh-dave/haxeui-templates.git
   - cd haxeui-templates/kha/skeleton
   - git clone --recursive --single-branch --depth=1 https://github.com/Kode/Kha.git
+  - mkdir Libraries
+  - cd Libraries
+  - git clone --single-branch --depth=1 https://github.com/haxeui/haxeui-core.git
+  - git clone --branch $TRAVIS_BRANCH --single-branch --depth=1 https://github.com/sh-dave/haxeui-kha.git
+  - git clone --single-branch --depth=1 https://github.com/haxefoundation/hscript.git
+  - cd ..
   - node Kha/make $BUILD_TARGET $BUILD_OPTS

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 Change Log
 ---------
+* 0.0.3
+  * Update to latest Kha api
 * 0.0.2
   * Support for mouse wheel events
   * Fixes for fonts

--- a/README.md
+++ b/README.md
@@ -1,35 +1,39 @@
-<p align="center">
-  <img src="http://haxeui.org/db/haxeui2-warning.png"/>
-</p>
+# haxeui-kha [![Build Status](https://travis-ci.org/haxeui/haxeui-kha.svg?branch=master)](https://travis-ci.org/haxeui/haxeui-kha)
 
-[![Build Status](https://travis-ci.org/haxeui/haxeui-kha.svg?branch=master)](https://travis-ci.org/haxeui/haxeui-kha)
-[![Support this project on Patreon](http://haxeui.org/db/patreon_button.png)](https://www.patreon.com/haxeui)
+This is the [Kha](https://github.com/Kode/Kha) backend for [HaxeUI](https://github.com/haxeui/haxeui-core)
 
-# haxeui-kha
-`haxeui-kha` is the `Kha` backend for HaxeUI.
+![](https://github.com/haxeui/haxeui-kha/raw/master/screen.png)
 
-<p align="center">
-	<img src="https://github.com/haxeui/haxeui-kha/raw/master/screen.png" />
-</p>
+## Support further development
+
+[![Support this project on Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/haxeui)
 
 ## Installation
- * `haxeui-kha` has a dependency to <a href="https://github.com/haxeui/haxeui-core">`haxeui-core`</a>, and so that too must be installed.
- * `haxeui-kha` also has a dependency to <a href="https://github.com/KTXSoftware/Kha">Kha</a>, please refer to the installation instructions on their <a href="https://github.com/KTXSoftware/Kha">site</a>.
 
-Eventually all these libs will become haxelibs, however, currently in their alpha form they do not even contain a `haxelib.json` file (for dependencies, etc) and therefore can only be used by downloading the source and using the `haxelib dev` command or by directly using the git versions using the `haxelib git` command (recommended). Eg:
+- `haxeui-kha` has a dependency to <a href="https://github.com/haxeui/haxeui-core">`haxeui-core`</a>, and so that too must be installed
+- `haxeui-kha` also has a dependency to [Kha](https://github.com/Kode/Kha), please refer to the installation instructions on their [site](https://kha.tech/getstarted)
+
+Eventually all these libs will become haxelibs, however, currently in their alpha form they do not even contain a `haxelib.json` file (for dependencies, etc) and therefore can only be used by using the git versions. Eg:
 
 ```
-haxelib git haxeui-core https://github.com/haxeui/haxeui-core
-haxelib dev haxeui-kha path/to/expanded/source/archive
+mkdir Libraries
+cd Libraries
+git clone https://github.com/haxeui/haxeui-core.git
+git clone https://github.com/haxeui/haxeui-kha.git
+git clone https://github.com/haxefoundation/hscript.git
 ```
+
+Or even better, add them as git submodules for proper versioning!
 
 ## Usage
-The simplest method to create a new `Kha` application that is HaxeUI ready is to use one of the <a href="https://github.com/haxeui/haxeui-templates">haxeui-templates</a>. These templates will allow you to start a new project rapidly with HaxeUI support baked in. 
 
-If however you already have an existing application, then incorporating HaxeUI into that application is straightforward:
+The simplest method to create a new `Kha` application that is HaxeUI ready is to use one of the [haxeui-templates](https://github.com/haxeui/haxeui-templates). These templates will allow you to start a new project rapidly with HaxeUI support baked in.
+
+If however you already have an existing application, then incorporating HaxeUI into that application is straightforward.
 
 ## khamake.js
-Simply add the following lines to your `khamake.js` and rebuild your project files (using `haxelib run kha html5` for example):
+
+Simply add the following lines to your `khamake.js` and rebuild your project files:
 
 ```js
 project.addLibrary('haxeui-core');
@@ -38,29 +42,38 @@ project.addLibrary('hscript');
 ```
 
 ### Toolkit initialisation and usage
+
 The `Kha` system itself must be initialised and a render loop started. This can be done by using code similar to:
 
 ```haxe
-public function new() {
-    Assets.loadEverything(onAssetsLoaded);
-}
+class Main {
+    public static function main() {
+        kha.System.start({}, function ( _ ) {
+            kha.Assets.loadEverything(function() {
+                haxe.ui.Toolkit.init();
 
-function onAssetsLoaded() {
-    Toolkit.init();
-    System.notifyOnRender(render);
-}
+                final screen = haxe.ui.core.Screen.instance;
+                final ui = haxe.ui.macros.ComponentMacros.buildComponent("ui.xml");
 
-function render(framebuffer:Framebuffer): Void {		
-    var g = framebuffer.g2;
-    g.begin(true, 0xFFFFFF);
-    Screen.instance.renderTo(g);
-    g.end();
+                screen.addComponent(ui);
+
+                kha.System.notifyOnFrames(function( framebuffers: Array<kha.Framebuffer> ) {
+                    final fb = framebuffers[0];
+                    final g2 = fb.g2;
+                    g2.begin(true, kha.Color.White);
+                        screen.renderTo(g2);
+                    g2.end();
+                });
+            });
+        });
+    }
 }
 ```
 
-Once the toolkit is initialised you can add components using the methods specified <a href="https://github.com/haxeui/haxeui-core#adding-components-using-haxe-code">here</a>.
+Once the toolkit is initialised you can add components using the methods specified [here](https://github.com/haxeui/haxeui-core#adding-components-using-haxe-code).
 
 ## Kha specifics
+
 As well as using the generic `Screen.instance.addComponent`, it is also possible to render a component to a specific surface use the components special `renderTo` function. Eg:
 
 ```haxe
@@ -74,4 +87,3 @@ main.renderTo(...);
 * <a href="https://github.com/haxeui/haxeui-templates">haxeui-templates</a> - Set of templates for IDE's to allow quick project creation.
 * <a href="https://github.com/haxeui/haxeui-bdd">haxeui-bdd</a> - A behaviour driven development engine written specifically for HaxeUI (uses <a href="https://github.com/haxeui/haxe-bdd">haxe-bdd</a> which is a gherkin/cucumber inspired project).
 * <a href="https://www.youtube.com/watch?v=L8J8qrR2VSg&feature=youtu.be">WWX2016 presentation</a> - A presentation given at WWX2016 regarding HaxeUI.
-

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "tags": ["ui", "gui", "kha"],
   "description": "The Kha backend of the HaxeUI framework",
-  "version": "0.0.2",
-  "releasenote": "Enhanced text input support",
+  "version": "0.0.3",
+  "releasenote": "Update to latest Kha api",
   "contributors": ["haxeui", "ianharrigan", "_ibilon", "aW4KeNiNG"],
   "dependencies": {
       "haxeui-core": ""


### PR DESCRIPTION
- updated sample code to latest kha api calls
- cleaned up the readme a bit (you should maybe add a proper patreon badge)
- travis builds for `html5`, `debug-html5` and `linux` now
  - doesn't use haxelib any longer, as thats not a recommended workflow when using kha