### PR TITLE
Replaces drawRect() with fillRect() for components borders

### DIFF
--- a/haxe/ui/backend/kha/StyleHelper.hx
+++ b/haxe/ui/backend/kha/StyleHelper.hx
@@ -121,14 +121,11 @@ class StyleHelper {
 
             var borderSize:Int = Std.int(style.borderLeftSize * Toolkit.scale);
             g.color = style.borderLeftColor | alpha;
-            for (i in 0...borderSize) {
-                g.drawRect(x, y, w, h, 1);
-                x++;
-                y++;
-                w -= 2;
-                h -= 2;
-            }
-            g.color = Color.White;
+            g.fillRect(x, y, w, borderSize); // top
+            g.fillRect(x, y + h - borderSize, w, borderSize); // bottom
+            g.fillRect(x, y, borderSize, h); // left
+            g.fillRect(x + w - borderSize, y, borderSize, h); // right
+            g.color = Color.White;    
         } else { // compound border
             if (style.borderTopSize != null && style.borderTopSize > 0) {
                 g.color = style.borderTopColor | alpha;


### PR DESCRIPTION
This fixes the problems caused by Kha's drawRect() not being HiDPI aware. For more information look at #42.
I've tested the implementation also with a border size greater than 1.