### PR TITLE
Make top components resize with the main window

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -130,10 +130,10 @@ class ScreenImpl extends ScreenBase {
 
         #if js
         _hasListener = true;
-		js.Browser.window.onresize = function(w:Int, h:Int) {
-           for (c in _topLevelComponents) {
-               resizeComponent(c);
-           }
+        js.Browser.window.onresize = function(w:Int, h:Int) {
+            for (c in _topLevelComponents) {
+                resizeComponent(c);
+            }
         };
         #end
     }

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -51,6 +51,7 @@ class ScreenImpl extends ScreenBase {
 
     public override function addComponent(component:Component):Component {
         _topLevelComponents.push(component);
+        addResizeListener();
         resizeComponent(component);
         //component.dispatchReady();
 		return component;
@@ -121,6 +122,22 @@ class ScreenImpl extends ScreenBase {
     //***********************************************************************************************************
     // Events
     //***********************************************************************************************************
+    private var _hasListener:Bool = false;
+    private function addResizeListener() {
+        if (_hasListener == true) {
+            return;
+        }
+
+        #if js
+        _hasListener = true;
+		js.Browser.window.onresize = function(w:Int, h:Int) {
+           for (c in _topLevelComponents) {
+               resizeComponent(c);
+           }
+        };
+        #end
+    }
+
     private override function supportsEvent(type:String):Bool {
         if (type == MouseEvent.MOUSE_MOVE
             || type == MouseEvent.MOUSE_DOWN


### PR DESCRIPTION
This is an attempt to fix issue #41, mimicking the resizeListener from haxeui-HTML5.

It works as expected, but I'm pretty sure I don't know enough about how haxeui-kha (and haxeui in general) deals with all the different targets.