### PR TITLE
Add support for the Window's resize event

### DIFF
--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -51,6 +51,7 @@ class ScreenImpl extends ScreenBase {
 
     public override function addComponent(component:Component):Component {
         _topLevelComponents.push(component);
+        addResizeListener();
         resizeComponent(component);
         //component.dispatchReady();
 		return component;
@@ -121,6 +122,20 @@ class ScreenImpl extends ScreenBase {
     //***********************************************************************************************************
     // Events
     //***********************************************************************************************************
+    private var _hasListener:Bool = false;
+    private function addResizeListener() {
+        if (_hasListener == true) {
+            return;
+        }
+
+        _hasListener = true;
+        kha.Window.get(0).notifyOnResize(function(w:Int,h:Int) {
+            for (c in _topLevelComponents) {
+                resizeComponent(c);
+            }
+        });
+    }
+
     private override function supportsEvent(type:String):Bool {
         if (type == MouseEvent.MOUSE_MOVE
             || type == MouseEvent.MOUSE_DOWN


### PR DESCRIPTION
Adding  support for the resize listener.
This time the code is using the Window from Kha and it is supposed to work with any Kha backend which implements the event.
The backends which don't support the event have an empty implementation for notifyOnResize(), this should be safe.
I've tried it on Kha-HTML5 with https://github.com/Kode/Kha/pull/1198 applied, and tried it as well with Kore-Metal, even if I cannot really say if there it is working (there are several other problems related with DPI).