### PR TITLE
Use Kha's cursor API with HaxeUI cursor styles

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -19,6 +19,7 @@ import kha.graphics2.Graphics;
 import kha.graphics2.ImageScaleQuality;
 import kha.input.KeyCode;
 import kha.input.Keyboard;
+import kha.System;
 
 class ComponentImpl extends ComponentBase {
     private var _eventMap:Map<String, UIEvent->Void>;
@@ -702,6 +703,9 @@ class ComponentImpl extends ComponentBase {
         lastMouseY = y;
         var i = inBounds(x, y);
         if (i == true) {
+            if (this.style != null) {
+                Screen.instance.setCursor(this.style.cursor);
+            }
             var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_MOVE);
             if (fn != null) {
                 var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_MOVE);
@@ -724,6 +728,7 @@ class ComponentImpl extends ComponentBase {
             }
         } else if (i == false && _mouseOverFlag == true) {
             _mouseOverFlag = false;
+            Screen.instance.setCursor("default");
             var fn:UIEvent->Void = _eventMap.get(haxe.ui.events.MouseEvent.MOUSE_OUT);
             if (fn != null) {
                 var mouseEvent = new haxe.ui.events.MouseEvent(haxe.ui.events.MouseEvent.MOUSE_OUT);
@@ -748,6 +753,11 @@ class ComponentImpl extends ComponentBase {
                 return;
             }
             _mouseDownFlag = true;
+
+            if (this.style != null && (this.style.cursor == "row-resize" || this.style.cursor == "col-resize")) {
+                Screen.instance.lockCursor();
+            }
+
             var type = button == 0 ? haxe.ui.events.MouseEvent.MOUSE_DOWN: haxe.ui.events.MouseEvent.RIGHT_MOUSE_DOWN;
             var fn:UIEvent->Void = _eventMap.get(type);
             if (fn != null) {
@@ -766,6 +776,13 @@ class ComponentImpl extends ComponentBase {
         
         lastMouseX = x;
         lastMouseY = y;
+
+        // Regardless of whether the mouse was released within the component, unlock the cursor if this component was selected
+        if (_mouseDownFlag) {
+            Screen.instance.unlockCursor();
+            Screen.instance.setCursor("default");
+        }
+
         var i = inBounds(x, y);
         if (i == true) {
             if (hasComponentOver(cast this, x, y) == true) {

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -11,9 +11,12 @@ import kha.Font;
 import kha.Scheduler;
 import kha.System;
 import kha.graphics2.Graphics;
+import kha.System;
+import kha.input.Mouse;
 
 class ScreenImpl extends ScreenBase {
     private var _mapping:Map<String, UIEvent->Void>;
+    private var cursorLocked:Bool = false;
 
     public function new() {
         _mapping = new Map<String, UIEvent->Void>();
@@ -75,6 +78,31 @@ class ScreenImpl extends ScreenBase {
             c.renderTo(g);
         }
         updateFPS(g);
+    }
+
+    public function setCursor(cursor:String, lock=false) {
+        if (cursorLocked) {
+            return;
+        }
+        cursorLocked = lock;
+
+        if (cursor == "pointer") {
+            kha.input.Mouse.get().setSystemCursor(MouseCursor.Pointer);
+        } else if (cursor == "text") {
+            kha.input.Mouse.get().setSystemCursor(MouseCursor.Text);
+        } else if (cursor == "col-resize") {
+            kha.input.Mouse.get().setSystemCursor(MouseCursor.EastWestResize);
+        } else if (cursor == "row-resize") {
+            kha.input.Mouse.get().setSystemCursor(MouseCursor.NorthSouthResize);
+        }else {
+            kha.input.Mouse.get().setSystemCursor(MouseCursor.Default);
+        }
+    }
+    public function lockCursor() {
+        cursorLocked = true;
+    }
+    public function unlockCursor() {
+        cursorLocked = false;
     }
 
     private var _deltaTime:Float;


### PR DESCRIPTION
Adds the cursor API and attempts to mitigate the issue where dragging a row-resize or col-resize component 'flashes' the cursor. The moved component moves under the cursor or lags a frame behind it - normally causing the cursor to rapidly change, hence the need for a cursor lock. It doesn't seem perfect yet and probably needs further work or a cleaner solution.

Instead of locking, could there be some storage of the 'held item', such that the cursor can always use that components style, regardless of whether the cursor is technically over the component?

On an aesthetic note, I think buttons might have the wrong cursor by default - trying a few apps (firefox, gimp, krita), it seems the current button cursor is used very scarcely (not in toolbars, for instance) and the default OS cursor is used instead. I think text fields aren't styled to give a text cursor style too. I didn't modify that here as those styles are in haxe-ui core. Let me know if you want me to create an issue in Haxe-UI core for these cursor style changes.