### PR TITLE
ComponentGraphics support

### DIFF
--- a/haxe/ui/backend/BatchOperation.hx
+++ b/haxe/ui/backend/BatchOperation.hx
@@ -1,6 +1,7 @@
 package haxe.ui.backend;
 
 import haxe.ui.core.Component;
+import haxe.ui.components.Canvas;
 
 @:enum @:unreflective
 enum BatchOperation {
@@ -8,6 +9,7 @@ enum BatchOperation {
     DrawImage(c:ComponentImpl);
     DrawText(c:ComponentImpl);
     DrawCustom(c:ComponentImpl);
+    DrawComponentGraphics(c:Canvas);
     ApplyScissor(x:Int, y:Int, w:Int, h:Int);
     ClearScissor;
 }

--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -8,7 +8,6 @@ import kha.Image;
 import kha.graphics2.Graphics;
 import kha.graphics4.TextureFormat;
 import kha.graphics4.Usage;
-import kha.Color as Kolor;
 import haxe.ui.util.Color;
 import haxe.ui.util.Variant.VariantType;
 
@@ -20,9 +19,6 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
     public function new(component:Component) {
         super(component);
     }
-    
-    inline function getKolor(c:Color, a:Int=255) 
-        return Kolor.fromBytes(c.r, c.g, c.b, a);
     
     public function renderTo(g:Graphics) {
         var currentPosition:Point = new Point();
@@ -37,20 +33,27 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
         var w = _component.width;
         var h = _component.height;
 
-        final getFillKolor = () -> getKolor(currentFillColor, currentFillAlpha);
-        final getStrokeKolor = () -> getKolor(currentStrokeColor, currentStrokeAlpha);
+        final getFillColor = () -> kha.Color.fromBytes(currentFillColor.r, 
+                                                       currentFillColor.g, 
+                                                       currentFillColor.b, 
+                                                       currentFillAlpha);
+
+        final getStrokeColor = () -> kha.Color.fromBytes(currentStrokeColor.r, 
+                                                         currentStrokeColor.g, 
+                                                         currentStrokeColor.b, 
+                                                         currentStrokeAlpha);
         
         for (command in _drawCommands) {
             switch (command) {
                 case Clear:
-                    g.color = Kolor.White;
+                    g.color = kha.Color.White;
                     g.fillRect(sx, sy, w, h);
                 case MoveTo(x, y):
                     currentPosition.x = x;
                     currentPosition.y = y;
                 case LineTo(x, y):
                     if (currentStrokeColor != -1) {
-                        g.color = getStrokeKolor();
+                        g.color = getStrokeColor();
                         g.drawLine(sx + currentPosition.x,
                                    sy + currentPosition.y,
                                    sx + x,
@@ -82,16 +85,16 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     }
                 case Circle(x, y, radius):
                     if (currentFillColor != -1) {
-                        g.color = getFillKolor();
+                        g.color = getFillColor();
                         g.fillCircle(sx + x, sy + y, radius + currentStrokeThickness);
                     }
                     if (currentStrokeColor != -1) {
-                        g.color = getStrokeKolor();
+                        g.color = getStrokeColor();
                         g.drawCircle(sx + x, sy + y, radius + currentStrokeThickness, currentStrokeThickness);
                     }
                 case CurveTo(controlX, controlY, anchorX, anchorY):
                     if (currentStrokeColor != -1) {
-                        g.color = getStrokeKolor();
+                        g.color = getStrokeColor();
                         final bezX = [sx + currentPosition.x, sx + controlX, sx + anchorX];
                         final bezY = [sy + currentPosition.y, sy + controlY, sy + anchorY];
                         g.drawQuadraticBezier(bezX, bezY, BEZIER_SEGMENTS, currentStrokeThickness);
@@ -100,7 +103,7 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     currentPosition.y = anchorY;
                 case CubicCurveTo(controlX1, controlY1, controlX2, controlY2, anchorX, anchorY):
                     if (currentStrokeColor != -1) {
-                        g.color = getStrokeKolor();
+                        g.color = getStrokeColor();
                         final bezX = [sx + currentPosition.x, sx + controlX1, sx + controlX2, sx + anchorX];
                         final bezY = [sy + currentPosition.y, sy + controlY1, sy + controlY2, sy + anchorY];
                         g.drawCubicBezier(bezX, bezY, BEZIER_SEGMENTS, currentStrokeThickness);
@@ -109,15 +112,15 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     currentPosition.y = anchorY;
                case Rectangle(x, y, width, height):
                     if (currentFillColor != -1) {
-                        g.color = getFillKolor();
+                        g.color = getFillColor();
                         g.fillRect(sx + x, sy + y, width, height);
                     }
                     if (currentStrokeColor != -1) {
-                        g.color = getStrokeKolor();
+                        g.color = getStrokeColor();
                         g.drawRect(sx + x, sy + y, width, height, currentStrokeThickness);
                     }
                case SetPixel(x, y, color):
-                    g.color = getKolor(color);
+                    g.color = kha.Color.fromValue(color);
                     g.fillRect(sx + x, sy + y, 1.0, 1.0); // probably not right
                case SetPixels(pixels):   
                     final img = Image.fromBytes(pixels, 

--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -10,6 +10,7 @@ import kha.graphics4.TextureFormat;
 import kha.graphics4.Usage;
 import kha.Color as Kolor;
 import haxe.ui.util.Color;
+import haxe.ui.util.Variant.VariantType;
 
 using haxe.ui.backend.kha.GraphicsExtension;
 
@@ -20,10 +21,6 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
         super(component);
     }
     
-    private var _image:Image = null;
-    private var _hasImage:Bool = false;
-    private var _lastBytes:Bytes = null;
-
     inline function getKolor(c:Color, a:Int=255) 
         return Kolor.fromBytes(c.r, c.g, c.b, a);
     
@@ -58,7 +55,7 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                                    sy + currentPosition.y,
                                    sx + x,
                                    sy + y,
-                                   currentStrokeThickness /* + .5 */);
+                                   currentStrokeThickness);
                     }
                     currentPosition.x = x;
                     currentPosition.y = y;
@@ -123,28 +120,18 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     g.color = getKolor(color);
                     g.fillRect(sx + x, sy + y, 1.0, 1.0); // probably not right
                case SetPixels(pixels):   
-                // TODO
-                //    if (_hasTexture == false) {
-                //        _hasTexture = true;
-                //        var image = Image.fromBytes(data, 
-                //                                    Std.int(_component.width), 
-                //                                    Std.int(_component.height), 
-                //                                    TextureFormat.RGBA32,
-                //                                    Usage.DynamicUsage,
-                //                                    true);
-                //        _texture = LoadTextureFromImage(image);
-                //        _lastBytes = pixels;
-                //        //UnloadImage(image);
-                //    } else if (_lastBytes != pixels) {
-                //        _lastBytes = pixels;
-                //        var data = NativeArray.address(pixels.getData(), 0);
-                //        UpdateTexture(_texture, data.rawCast());
-                //    }
-                   
-
-                //    DrawTexture(_texture, sx, sy, Colors.WHITE);
+                    final img = Image.fromBytes(pixels, 
+                                                Std.int(w), 
+                                                Std.int(h),
+                                                TextureFormat.RGBA32,
+                                                Usage.StaticUsage);
+                    g.drawImage(img, sx, sy);
                case Image(resource, x, y, width, height):
-                // TODO
+                    switch (resource) {
+                        case VT_ImageData(img):
+                            g.drawScaledImage(img, sx + x, sy + y, width, height);
+                        default:
+                    }
             }
         }
     }

--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -11,8 +11,11 @@ import kha.graphics4.Usage;
 import kha.Color as Kolor;
 import haxe.ui.util.Color;
 
+using haxe.ui.backend.kha.GraphicsExtension;
 
 class ComponentGraphicsImpl extends ComponentGraphicsBase {
+    static inline final BEZIER_SEGMENTS = 20;
+
     public function new(component:Component) {
         super(component);
     }
@@ -82,40 +85,28 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     }
                 case Circle(x, y, radius):
                     if (currentFillColor != -1) {
-                        //TODO
-                        // DrawCircleGradient(Std.int(sx + x),
-                        //                    Std.int(sy + y),
-                        //                    radius + currentStrokeThickness - 1,
-                        //                    getFillKolor(),
-                        //                    getFillKolor());
+                        g.color = getFillKolor();
+                        g.fillCircle(sx + x, sy + y, radius + currentStrokeThickness);
                     }
                     if (currentStrokeColor != -1) {
-                        //TODO
-                        // DrawCircle(Std.int(sx + x),
-                        //            Std.int(sy + y),
-                        //            radius + currentStrokeThickness - 1,
-                        //            getStrokeKolor());
+                        g.color = getStrokeKolor();
+                        g.drawCircle(sx + x, sy + y, radius + currentStrokeThickness, currentStrokeThickness);
                     }
                 case CurveTo(controlX, controlY, anchorX, anchorY):
                     if (currentStrokeColor != -1) {
-                        //TODO
-                        // DrawLineBezierQuad(new Vector2(sx + currentPosition.x, sy + currentPosition.y),
-                        //                    new Vector2(sx + anchorX, sy + anchorY),
-                        //                    new Vector2(sx + controlX, sy + controlY),
-                        //                    currentStrokeThickness + .5,
-                        //                    getStrokeKolor());
+                        g.color = getStrokeKolor();
+                        final bezX = [sx + currentPosition.x, sx + controlX, sx + anchorX];
+                        final bezY = [sy + currentPosition.y, sy + controlY, sy + anchorY];
+                        g.drawQuadraticBezier(bezX, bezY, BEZIER_SEGMENTS, currentStrokeThickness);
                     }
                     currentPosition.x = anchorX;
                     currentPosition.y = anchorY;
                 case CubicCurveTo(controlX1, controlY1, controlX2, controlY2, anchorX, anchorY):
                     if (currentStrokeColor != -1) {
-                        //TODO
-                        // DrawLineBezierCubic(new Vector2(sx + currentPosition.x, sy + currentPosition.y),
-                        //                     new Vector2(sx + anchorX, sy + anchorY),
-                        //                     new Vector2(sx + controlX1, sy + controlY1),
-                        //                     new Vector2(sx + controlX2, sy + controlY2),
-                        //                     currentStrokeThickness + .5,
-                        //                     getStrokeKolor());
+                        g.color = getStrokeKolor();
+                        final bezX = [sx + currentPosition.x, sx + controlX1, sx + controlX2, sx + anchorX];
+                        final bezY = [sy + currentPosition.y, sy + controlY1, sy + controlY2, sy + anchorY];
+                        g.drawCubicBezier(bezX, bezY, BEZIER_SEGMENTS, currentStrokeThickness);
                     }
                     currentPosition.x = anchorX;
                     currentPosition.y = anchorY;
@@ -123,6 +114,10 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                     if (currentFillColor != -1) {
                         g.color = getFillKolor();
                         g.fillRect(sx + x, sy + y, width, height);
+                    }
+                    if (currentStrokeColor != -1) {
+                        g.color = getStrokeKolor();
+                        g.drawRect(sx + x, sy + y, width, height, currentStrokeThickness);
                     }
                case SetPixel(x, y, color):
                     g.color = getKolor(color);

--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -1,4 +1,156 @@
 package haxe.ui.backend;
 
+import haxe.io.Bytes;
+import haxe.ui.core.Component;
+import haxe.ui.geom.Point;
+import kha.math.Vector2;
+import kha.Image;
+import kha.graphics2.Graphics;
+import kha.graphics4.TextureFormat;
+import kha.graphics4.Usage;
+import kha.Color as Kolor;
+import haxe.ui.util.Color;
+
+
 class ComponentGraphicsImpl extends ComponentGraphicsBase {
+    public function new(component:Component) {
+        super(component);
+    }
+    
+    private var _image:Image = null;
+    private var _hasImage:Bool = false;
+    private var _lastBytes:Bytes = null;
+
+    inline function getKolor(c:Color, a:Int=255) 
+        return Kolor.fromBytes(c.r, c.g, c.b, a);
+    
+    public function renderTo(g:Graphics) {
+        var currentPosition:Point = new Point();
+        var currentStrokeColor:Color = -1;
+        var currentStrokeThickness:Float = 1;
+        var currentStrokeAlpha:Int = 255;
+        var currentFillColor:Color = -1;
+        var currentFillAlpha:Int = 255;
+        
+        var sx = _component.screenLeft;
+        var sy = _component.screenTop;
+        var w = _component.width;
+        var h = _component.height;
+
+        final getFillKolor = () -> getKolor(currentFillColor, currentFillAlpha);
+        final getStrokeKolor = () -> getKolor(currentStrokeColor, currentStrokeAlpha);
+        
+        for (command in _drawCommands) {
+            switch (command) {
+                case Clear:
+                    g.color = Kolor.White;
+                    g.fillRect(sx, sy, w, h);
+                case MoveTo(x, y):
+                    currentPosition.x = x;
+                    currentPosition.y = y;
+                case LineTo(x, y):
+                    if (currentStrokeColor != -1) {
+                        g.color = getStrokeKolor();
+                        g.drawLine(sx + currentPosition.x,
+                                   sy + currentPosition.y,
+                                   sx + x,
+                                   sy + y,
+                                   currentStrokeThickness /* + .5 */);
+                    }
+                    currentPosition.x = x;
+                    currentPosition.y = y;
+                case StrokeStyle(color, thickness, alpha):
+                    if (thickness != null) {
+                        currentStrokeThickness = thickness;
+                    }
+                    if (color != null) {
+                        currentStrokeColor = color;
+                    } else {
+                        currentStrokeColor = -1;
+                    }
+                    if (alpha != null) {
+                        currentStrokeAlpha = Std.int(alpha * 255);
+                    }
+                case FillStyle(color, alpha):
+                    if (color != null) {
+                        currentFillColor = color;
+                    } else {
+                        currentFillColor = -1;
+                    }
+                    if (alpha != null) {
+                        currentFillAlpha = Std.int(alpha * 255);
+                    }
+                case Circle(x, y, radius):
+                    if (currentFillColor != -1) {
+                        //TODO
+                        // DrawCircleGradient(Std.int(sx + x),
+                        //                    Std.int(sy + y),
+                        //                    radius + currentStrokeThickness - 1,
+                        //                    getFillKolor(),
+                        //                    getFillKolor());
+                    }
+                    if (currentStrokeColor != -1) {
+                        //TODO
+                        // DrawCircle(Std.int(sx + x),
+                        //            Std.int(sy + y),
+                        //            radius + currentStrokeThickness - 1,
+                        //            getStrokeKolor());
+                    }
+                case CurveTo(controlX, controlY, anchorX, anchorY):
+                    if (currentStrokeColor != -1) {
+                        //TODO
+                        // DrawLineBezierQuad(new Vector2(sx + currentPosition.x, sy + currentPosition.y),
+                        //                    new Vector2(sx + anchorX, sy + anchorY),
+                        //                    new Vector2(sx + controlX, sy + controlY),
+                        //                    currentStrokeThickness + .5,
+                        //                    getStrokeKolor());
+                    }
+                    currentPosition.x = anchorX;
+                    currentPosition.y = anchorY;
+                case CubicCurveTo(controlX1, controlY1, controlX2, controlY2, anchorX, anchorY):
+                    if (currentStrokeColor != -1) {
+                        //TODO
+                        // DrawLineBezierCubic(new Vector2(sx + currentPosition.x, sy + currentPosition.y),
+                        //                     new Vector2(sx + anchorX, sy + anchorY),
+                        //                     new Vector2(sx + controlX1, sy + controlY1),
+                        //                     new Vector2(sx + controlX2, sy + controlY2),
+                        //                     currentStrokeThickness + .5,
+                        //                     getStrokeKolor());
+                    }
+                    currentPosition.x = anchorX;
+                    currentPosition.y = anchorY;
+               case Rectangle(x, y, width, height):
+                    if (currentFillColor != -1) {
+                        g.color = getFillKolor();
+                        g.fillRect(sx + x, sy + y, width, height);
+                    }
+               case SetPixel(x, y, color):
+                    g.color = getKolor(color);
+                    g.fillRect(sx + x, sy + y, 1.0, 1.0); // probably not right
+               case SetPixels(pixels):   
+                // TODO
+                //    if (_hasTexture == false) {
+                //        _hasTexture = true;
+                //        var image = Image.fromBytes(data, 
+                //                                    Std.int(_component.width), 
+                //                                    Std.int(_component.height), 
+                //                                    TextureFormat.RGBA32,
+                //                                    Usage.DynamicUsage,
+                //                                    true);
+                //        _texture = LoadTextureFromImage(image);
+                //        _lastBytes = pixels;
+                //        //UnloadImage(image);
+                //    } else if (_lastBytes != pixels) {
+                //        _lastBytes = pixels;
+                //        var data = NativeArray.address(pixels.getData(), 0);
+                //        UpdateTexture(_texture, data.rawCast());
+                //    }
+                   
+
+                //    DrawTexture(_texture, sx, sy, Colors.WHITE);
+               case Image(resource, x, y, width, height):
+                // TODO
+            }
+        }
+    }
 }

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -262,6 +262,11 @@ class ComponentImpl extends ComponentBase {
             return;
         }
 
+        if ((this is haxe.ui.components.Canvas)) {
+            cast(this, haxe.ui.components.Canvas).componentGraphics.renderTo(g);
+            return;
+        }
+
         clearCaches();
 
         if (isOffscreen() == true) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -9,6 +9,7 @@ import haxe.ui.backend.kha.ScissorHelper;
 import haxe.ui.backend.kha.StyleHelper;
 import haxe.ui.core.Component;
 import haxe.ui.core.Screen;
+import haxe.ui.components.Canvas;
 import haxe.ui.events.KeyboardEvent;
 import haxe.ui.events.MouseEvent;
 import haxe.ui.events.UIEvent;
@@ -262,11 +263,6 @@ class ComponentImpl extends ComponentBase {
             return;
         }
 
-        if ((this is haxe.ui.components.Canvas)) {
-            cast(this, haxe.ui.components.Canvas).componentGraphics.renderTo(g);
-            return;
-        }
-
         clearCaches();
 
         if (isOffscreen() == true) {
@@ -328,6 +324,14 @@ class ComponentImpl extends ComponentBase {
             }
         }
 
+        if (this is haxe.ui.components.Canvas) {
+            if (batch) {
+                addBatchStyleOperation(DrawComponentGraphics(cast this));
+            } else {
+                renderComponentGraphicsTo(g, cast this);
+            }
+        }
+
         if (batch) {
             addBatchStyleOperation(DrawCustom(this));
         } else {
@@ -384,6 +388,8 @@ class ComponentImpl extends ComponentBase {
                     renderTextTo(g, c);
                 case DrawCustom(c):
                     c.renderCustom(g);
+                case DrawComponentGraphics(c):
+                    renderComponentGraphicsTo(g, c);
                 case ClearScissor:
                     ScissorHelper.popScissor();
             }
@@ -465,6 +471,10 @@ class ComponentImpl extends ComponentBase {
 
         g.color = Color.White;
         g.opacity = 1;
+    }
+
+    private function renderComponentGraphicsTo(g:Graphics, c:Canvas) {
+        c.componentGraphics.renderTo(g);
     }
 
     private var _componentBuffer:kha.Image;

--- a/haxe/ui/backend/kha/GraphicsExtension.hx
+++ b/haxe/ui/backend/kha/GraphicsExtension.hx
@@ -7,9 +7,14 @@ import kha.graphics2.VerTextAlignment;
 import kha.graphics2.HorTextAlignment;
 
 /**
- * Static extension functions for Graphics2.
- * Usage: "using kha.graphics2.GraphicsExtension;"
+ * Copied directly from kha.graphics2.GraphicsExtension per the suggestions in the @:deprecated metadata.
+ * My only additions were the quadratic bezier functions, derived from the cubic bezier functions.
  */
+
+/**
+ * Static extension functions for Graphics2.
+ * Usage: "using haxe.ui.backend.kha.GraphicsExtension;"
+ **/
 class GraphicsExtension {
 	/**
 	 * Draws a arc.
@@ -309,7 +314,7 @@ class GraphicsExtension {
 
 	/**
 	 * Draws a quadratic bezier using 3 pairs of points. 
-	 * Provide x and y in the following order: startPoint, controlPoint, controlPoint, endPoint
+	 * Provide x and y in the following order: startPoint, controlPoint, endPoint
 	 */
 	public static function drawQuadraticBezier(g2: Graphics, x: Array<Float>, y: Array<Float>, segments: Int = 20, strength: Float = 1.0): Void {
 		var t: Float;

--- a/haxe/ui/backend/kha/GraphicsExtension.hx
+++ b/haxe/ui/backend/kha/GraphicsExtension.hx
@@ -1,0 +1,419 @@
+package haxe.ui.backend.kha;
+
+import kha.math.Vector2;
+import kha.math.FastVector2;
+import kha.graphics2.Graphics;
+import kha.graphics2.VerTextAlignment;
+import kha.graphics2.HorTextAlignment;
+
+/**
+ * Static extension functions for Graphics2.
+ * Usage: "using kha.graphics2.GraphicsExtension;"
+ */
+class GraphicsExtension {
+	/**
+	 * Draws a arc.
+	 * @param	ccw (optional) Specifies whether the drawing should be counterclockwise.
+	 * @param	segments (optional) The amount of lines that should be used to draw the arc.
+	 */
+	public static function drawArc(g2: Graphics, cx: Float, cy: Float, radius: Float, sAngle: Float, eAngle: Float, strength: Float = 1, ccw: Bool = false,
+			segments: Int = 0): Void {
+		#if kha_html5
+		if (kha.SystemImpl.gl == null) {
+			var g: kha.js.CanvasGraphics = cast g2;
+			radius -= strength / 2; // reduce radius to fit the line thickness within image width/height
+			g.drawArc(cx, cy, radius, sAngle, eAngle, strength, ccw);
+			return;
+		}
+		#end
+
+		sAngle = sAngle % (Math.PI * 2);
+		eAngle = eAngle % (Math.PI * 2);
+
+		if (ccw) {
+			if (eAngle > sAngle)
+				eAngle -= Math.PI * 2;
+		}
+		else if (eAngle < sAngle)
+			eAngle += Math.PI * 2;
+
+		radius += strength / 2;
+		if (segments <= 0)
+			segments = Math.floor(10 * Math.sqrt(radius));
+
+		var theta = (eAngle - sAngle) / segments;
+		var c = Math.cos(theta);
+		var s = Math.sin(theta);
+
+		var x = Math.cos(sAngle) * radius;
+		var y = Math.sin(sAngle) * radius;
+
+		for (n in 0...segments) {
+			var px = x + cx;
+			var py = y + cy;
+
+			var t = x;
+			x = c * x - s * y;
+			y = c * y + s * t;
+
+			drawInnerLine(g2, x + cx, y + cy, px, py, strength);
+		}
+	}
+
+	/**
+	 * Draws a filled arc.
+	 * @param	ccw (optional) Specifies whether the drawing should be counterclockwise.
+	 * @param	segments (optional) The amount of lines that should be used to draw the arc.
+	 */
+	public static function fillArc(g2: Graphics, cx: Float, cy: Float, radius: Float, sAngle: Float, eAngle: Float, ccw: Bool = false,
+			segments: Int = 0): Void {
+		#if kha_html5
+		if (kha.SystemImpl.gl == null) {
+			var g: kha.js.CanvasGraphics = cast g2;
+			g.fillArc(cx, cy, radius, sAngle, eAngle, ccw);
+			return;
+		}
+		#end
+
+		sAngle = sAngle % (Math.PI * 2);
+		eAngle = eAngle % (Math.PI * 2);
+
+		if (ccw) {
+			if (eAngle > sAngle)
+				eAngle -= Math.PI * 2;
+		}
+		else if (eAngle < sAngle)
+			eAngle += Math.PI * 2;
+
+		if (segments <= 0)
+			segments = Math.floor(10 * Math.sqrt(radius));
+
+		var theta = (eAngle - sAngle) / segments;
+		var c = Math.cos(theta);
+		var s = Math.sin(theta);
+
+		var x = Math.cos(sAngle) * radius;
+		var y = Math.sin(sAngle) * radius;
+		var sx = x + cx;
+		var sy = y + cy;
+
+		for (n in 0...segments) {
+			var px = x + cx;
+			var py = y + cy;
+
+			var t = x;
+			x = c * x - s * y;
+			y = c * y + s * t;
+
+			g2.fillTriangle(px, py, x + cx, y + cy, sx, sy);
+		}
+	}
+
+	/**
+	 * Draws a circle.
+	 * @param	segments (optional) The amount of lines that should be used to draw the circle.
+	 */
+	public static function drawCircle(g2: Graphics, cx: Float, cy: Float, radius: Float, strength: Float = 1, segments: Int = 0): Void {
+		#if kha_html5
+		if (kha.SystemImpl.gl == null) {
+			var g: kha.js.CanvasGraphics = cast g2;
+			radius -= strength / 2; // reduce radius to fit the line thickness within image width/height
+			g.drawCircle(cx, cy, radius, strength);
+			return;
+		}
+		#end
+		radius += strength / 2;
+
+		if (segments <= 0)
+			segments = Math.floor(10 * Math.sqrt(radius));
+
+		var theta = 2 * Math.PI / segments;
+		var c = Math.cos(theta);
+		var s = Math.sin(theta);
+
+		var x = radius;
+		var y = 0.0;
+
+		for (n in 0...segments) {
+			var px = x + cx;
+			var py = y + cy;
+
+			var t = x;
+			x = c * x - s * y;
+			y = c * y + s * t;
+			drawInnerLine(g2, x + cx, y + cy, px, py, strength);
+		}
+	}
+
+	static function drawInnerLine(g2: Graphics, x1: Float, y1: Float, x2: Float, y2: Float, strength: Float): Void {
+		var side = y2 > y1 ? 1 : 0;
+		if (y2 == y1)
+			side = x2 - x1 > 0 ? 1 : 0;
+
+		var vec = new FastVector2();
+		if (y2 == y1)
+			vec.setFrom(new FastVector2(0, -1));
+		else
+			vec.setFrom(new FastVector2(1, -(x2 - x1) / (y2 - y1)));
+		vec.length = strength;
+		var p1 = new FastVector2(x1 + side * vec.x, y1 + side * vec.y);
+		var p2 = new FastVector2(x2 + side * vec.x, y2 + side * vec.y);
+		var p3 = p1.sub(vec);
+		var p4 = p2.sub(vec);
+		g2.fillTriangle(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y);
+		g2.fillTriangle(p3.x, p3.y, p2.x, p2.y, p4.x, p4.y);
+	}
+
+	/**
+	 * Draws a filled circle.
+	 * @param	segments (optional) The amount of lines that should be used to draw the circle.
+	 */
+	public static function fillCircle(g2: Graphics, cx: Float, cy: Float, radius: Float, segments: Int = 0): Void {
+		#if kha_html5
+		if (kha.SystemImpl.gl == null) {
+			var g: kha.js.CanvasGraphics = cast g2;
+			g.fillCircle(cx, cy, radius);
+			return;
+		}
+		#end
+
+		if (segments <= 0) {
+			segments = Math.floor(10 * Math.sqrt(radius));
+		}
+
+		var theta = 2 * Math.PI / segments;
+		var c = Math.cos(theta);
+		var s = Math.sin(theta);
+
+		var x = radius;
+		var y = 0.0;
+
+		for (n in 0...segments) {
+			var px = x + cx;
+			var py = y + cy;
+
+			var t = x;
+			x = c * x - s * y;
+			y = c * y + s * t;
+
+			g2.fillTriangle(px, py, x + cx, y + cy, cx, cy);
+		}
+	}
+
+	/**
+	 * Draws a convex polygon.
+	 */
+	public static function drawPolygon(g2: Graphics, x: Float, y: Float, vertices: Array<Vector2>, strength: Float = 1) {
+		var iterator = vertices.iterator();
+		var v0 = iterator.next();
+		var v1 = v0;
+
+		while (iterator.hasNext()) {
+			var v2 = iterator.next();
+			g2.drawLine(v1.x + x, v1.y + y, v2.x + x, v2.y + y, strength);
+			v1 = v2;
+		}
+		g2.drawLine(v1.x + x, v1.y + y, v0.x + x, v0.y + y, strength);
+	}
+
+	/**
+	 * Draws a filled convex polygon.
+	 */
+	public static function fillPolygon(g2: Graphics, x: Float, y: Float, vertices: Array<Vector2>) {
+		var iterator = vertices.iterator();
+
+		if (!iterator.hasNext())
+			return;
+		var v0 = iterator.next();
+
+		if (!iterator.hasNext())
+			return;
+		var v1 = iterator.next();
+
+		while (iterator.hasNext()) {
+			var v2 = iterator.next();
+			g2.fillTriangle(v0.x + x, v0.y + y, v1.x + x, v1.y + y, v2.x + x, v2.y + y);
+			v1 = v2;
+		}
+	}
+
+	/**
+	 * Draws a cubic bezier using 4 pairs of points. If the x and y arrays have a length bigger then 4, the additional
+	 * points will be ignored. With a length smaller of 4 a error will occur, there is no check for this.
+	 * You can construct the curves visually in Inkscape with a path using default nodes.
+	 * Provide x and y in the following order: startPoint, controlPoint1, controlPoint2, endPoint
+	 * Reference: http://devmag.org.za/2011/04/05/bzier-curves-a-tutorial/
+	 */
+	public static function drawCubicBezier(g2: Graphics, x: Array<Float>, y: Array<Float>, segments: Int = 20, strength: Float = 1.0): Void {
+		var t: Float;
+
+		var q0 = calculateCubicBezierPoint(0, x, y);
+		var q1: Array<Float>;
+
+		for (i in 1...(segments + 1)) {
+			t = i / segments;
+			q1 = calculateCubicBezierPoint(t, x, y);
+			g2.drawLine(q0[0], q0[1], q1[0], q1[1], strength);
+			q0 = q1;
+		}
+	}
+
+	/**
+	 * Draws multiple cubic beziers joined by the end point. The minimum size is 4 pairs of points (a single curve).
+	 */
+	public static function drawCubicBezierPath(g2: Graphics, x: Array<Float>, y: Array<Float>, segments: Int = 20, strength: Float = 1.0): Void {
+		var i = 0;
+		var t: Float;
+		var q0: Array<Float> = null;
+		var q1: Array<Float> = null;
+
+		while (i < x.length - 3) {
+			if (i == 0)
+				q0 = calculateCubicBezierPoint(0, [x[i], x[i + 1], x[i + 2], x[i + 3]], [y[i], y[i + 1], y[i + 2], y[i + 3]]);
+
+			for (j in 1...(segments + 1)) {
+				t = j / segments;
+				q1 = calculateCubicBezierPoint(t, [x[i], x[i + 1], x[i + 2], x[i + 3]], [y[i], y[i + 1], y[i + 2], y[i + 3]]);
+				g2.drawLine(q0[0], q0[1], q1[0], q1[1], strength);
+				q0 = q1;
+			}
+
+			i += 3;
+		}
+	}
+
+	static function calculateCubicBezierPoint(t: Float, x: Array<Float>, y: Array<Float>): Array<Float> {
+		var u: Float = 1 - t;
+		var tt: Float = t * t;
+		var uu: Float = u * u;
+		var uuu: Float = uu * u;
+		var ttt: Float = tt * t;
+
+		// first term
+		var p: Array<Float> = [uuu * x[0], uuu * y[0]];
+
+		// second term
+		p[0] += 3 * uu * t * x[1];
+		p[1] += 3 * uu * t * y[1];
+
+		// third term
+		p[0] += 3 * u * tt * x[2];
+		p[1] += 3 * u * tt * y[2];
+
+		// fourth term
+		p[0] += ttt * x[3];
+		p[1] += ttt * y[3];
+
+		return p;
+	}
+
+	/**
+	 * Draws a quadratic bezier using 3 pairs of points. 
+	 * Provide x and y in the following order: startPoint, controlPoint, controlPoint, endPoint
+	 */
+	public static function drawQuadraticBezier(g2: Graphics, x: Array<Float>, y: Array<Float>, segments: Int = 20, strength: Float = 1.0): Void {
+		var t: Float;
+
+		var q0 = calculateQuadraticBezierPoint(0, x, y);
+		var q1: Array<Float>;
+
+		for (i in 1...(segments + 1)) {
+			t = i / segments;
+			q1 = calculateQuadraticBezierPoint(t, x, y);
+			g2.drawLine(q0[0], q0[1], q1[0], q1[1], strength);
+			q0 = q1;
+		}
+	}
+
+	/**
+	 * Draws multiple quadratic beziers joined by the end point. The minimum size is 3 pairs of points (a single curve).
+	 */
+	public static function drawQuadraticBezierPath(g2: Graphics, x: Array<Float>, y: Array<Float>, segments: Int = 20, strength: Float = 1.0): Void {
+		var i = 0;
+		var t: Float;
+		var q0: Array<Float> = null;
+		var q1: Array<Float> = null;
+
+		while (i < x.length - 2) {
+			if (i == 0)
+				q0 = calculateQuadraticBezierPoint(0, [x[i], x[i + 1], x[i + 2]], [y[i], y[i + 1], y[i + 2]]);
+
+			for (j in 1...(segments + 1)) {
+				t = j / segments;
+				q1 = calculateQuadraticBezierPoint(t, [x[i], x[i + 1], x[i + 2]], [y[i], y[i + 1], y[i + 2]]);
+				g2.drawLine(q0[0], q0[1], q1[0], q1[1], strength);
+				q0 = q1;
+			}
+
+			i += 3;
+		}
+	}
+
+	static function calculateQuadraticBezierPoint(t: Float, x: Array<Float>, y: Array<Float>): Array<Float> {
+		var u: Float = 1 - t;
+		var tt: Float = t * t;
+		var uu: Float = u * u;
+
+		// first term
+		var p: Array<Float> = [uu * x[0], uu * y[0]];
+
+		// second term
+		p[0] += 2 * u * t * x[1];
+		p[1] += 2 * u * t * y[1];
+
+		// third term
+		p[0] += tt * x[2];
+		p[1] += tt * y[2];
+
+		return p;
+	}
+
+	static public function drawAlignedString(g2: Graphics, text: String, x: Float, y: Float, horAlign: HorTextAlignment, verAlign: VerTextAlignment): Void {
+		var xoffset = 0.0;
+		if (horAlign == TextCenter || horAlign == TextRight) {
+			var width = g2.font.width(g2.fontSize, text);
+			if (horAlign == TextCenter) {
+				xoffset = -width * 0.5;
+			}
+			else {
+				xoffset = -width;
+			}
+		}
+		var yoffset = 0.0;
+		if (verAlign == TextMiddle || verAlign == TextBottom) {
+			var height = g2.font.height(g2.fontSize);
+			if (verAlign == TextMiddle) {
+				yoffset = -height * 0.5;
+			}
+			else {
+				yoffset = -height;
+			}
+		}
+		g2.drawString(text, x + xoffset, y + yoffset);
+	}
+
+	static public function drawAlignedCharacters(g2: Graphics, text: Array<Int>, start: Int, length: Int, x: Float, y: Float, horAlign: HorTextAlignment,
+			verAlign: VerTextAlignment): Void {
+		var xoffset = 0.0;
+		if (horAlign == TextCenter || horAlign == TextRight) {
+			var width = g2.font.widthOfCharacters(g2.fontSize, text, start, length);
+			if (horAlign == TextCenter) {
+				xoffset = -width * 0.5;
+			}
+			else {
+				xoffset = -width;
+			}
+		}
+		var yoffset = 0.0;
+		if (verAlign == TextMiddle || verAlign == TextBottom) {
+			var height = g2.font.height(g2.fontSize);
+			if (verAlign == TextMiddle) {
+				yoffset = -height * 0.5;
+			}
+			else {
+				yoffset = -height;
+			}
+		}
+		g2.drawCharacters(text, start, length, x + xoffset, y + yoffset);
+	}
+}


### PR DESCRIPTION
Implementation of previously-empty `ComponentGraphicsImpl` for use in `Canvas` components, based partially on HaxeUI-RayLib implementation as suggested on Discord. Created as a practice exercise with `kha.Graphics2`.

Also adds a `DrawComponentGraphics` constructor to `BatchOperation` to play nicely with batching, scissors, etc.

Tested against the Component Explorer "Canvas" and "Canvas/As Icons" examples here: 
https://github.com/AbeGellis/HaxeUI-Kha-ComponentGraphics-Impl