### PR TITLE
Zero out scissor dimensions when negative

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -378,9 +378,7 @@ class ComponentImpl extends ComponentBase {
         for (op in operations) {
             switch (op) {
                 case ApplyScissor(sx, sy, sw, sh):
-                    if (sw >= 0 && sh >= 0) {
-                        ScissorHelper.pushScissor(g, sx, sy, sw, sh);
-                    }
+                    ScissorHelper.pushScissor(g, sx, sy, sw > 0 ? sw : 0, sh > 0 ? sh : 0);
                 case DrawStyle(c):
                     renderStyleTo(g, c);
                 case DrawImage(c):


### PR DESCRIPTION
Prevents skipping the push operation and incurring a scissor-stack push/pop mismatch.

Negative-dimension scissor operation reproduction case can be found [here](https://github.com/AbeGellis/HaxeUI-ScissorUnderflow-Repro).