### PR TITLE
Fixed `Unmatched patterns: BeginPath | ClosePath`

### DIFF
--- a/haxe/ui/backend/ComponentGraphicsImpl.hx
+++ b/haxe/ui/backend/ComponentGraphicsImpl.hx
@@ -135,6 +135,8 @@ class ComponentGraphicsImpl extends ComponentGraphicsBase {
                             g.drawScaledImage(img, sx + x, sy + y, width, height);
                         default:
                     }
+                case _:
+                    // Handle any other commands or ignore them
             }
         }
     }


### PR DESCRIPTION
```
haxeui-kha/haxe/ui/backend/ComponentGraphicsImpl.hx:47: characters 21-28: Unmatched patterns: BeginPath | ClosePath
```

Fixed the error I've been receiving while using Kha HaxeUI.